### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,11 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
   private
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birthday])
-  end
 
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana,
+                                             :birthday])
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :create]
+  before_action :authenticate_user!, only: [:new, :edit, :create,:update]
+  before_action :set_item          , only: [:edit,:update]
+  before_action :move_to_index     , only: [:edit,:update]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -14,12 +16,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
-    redirect_to root_path unless current_user.id == @item.user.id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -42,4 +41,14 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:image, :name, :explanation, :category_id, :condition_id, :delivery_fee_id, :prefecture_id,
                                  :delivery_day_id, :price).merge(user_id: current_user.id)
   end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    redirect_to root_path unless current_user.id == @item.user.id
+  end
+
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,6 +13,22 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+    unless current_user.id == @item.user.id
+      redirect_to root_path
+    end
+  end
+  
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+       redirect_to item_path
+    else
+      render:edit
+    end
+  end
+
 
   def create
     @item = Item.new(item_params)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new,:edit,:create]
+  before_action :authenticate_user!, only: [:new, :edit, :create]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -15,34 +15,31 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-    unless current_user.id == @item.user.id
-      redirect_to root_path
-    end
+    redirect_to root_path unless current_user.id == @item.user.id
   end
-  
+
   def update
     @item = Item.find(params[:id])
     if @item.update(item_params)
-       redirect_to item_path
+      redirect_to item_path
     else
-      render:edit
+      render :edit
     end
   end
 
-
   def create
     @item = Item.new(item_params)
-     if @item.save
-       redirect_to root_path
-     else 
+    if @item.save
+      redirect_to root_path
+    else
       render :new
-     end
+    end
   end
 
-private
+  private
+
   def item_params
-     params.require(:item).permit(:image,:name,:explanation,:category_id,:condition_id,:delivery_fee_id,:prefecture_id,:delivery_day_id,:price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :explanation, :category_id, :condition_id, :delivery_fee_id, :prefecture_id,
+                                 :delivery_day_id, :price).merge(user_id: current_user.id)
   end
-
 end
-

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,18 +1,17 @@
 class Category < ActiveHash::Base
-    self.data = [
-      { id: 1, name: '--' },
-      { id: 2, name: 'レディース'},
-      { id: 3, name: 'メンズ'},
-      { id: 4, name: 'ベビー・キッズ'},
-      { id: 5, name: 'インテリア・住まい・小物'},
-      { id: 6, name: '本・音楽・ゲーム'},
-      { id: 7, name: 'おもちゃ・ホビー・ゲーム'},
-      { id: 8, name: '家電・スマホ・カメラ'},
-      { id: 9, name: 'スポーツ・レジャー'},
-      { id: 10, name: 'ハンドメイド'},
-      { id: 11, name: 'その他'}
-    ]
+  self.data = [
+    { id: 1, name: '--' },
+    { id: 2, name: 'レディース' },
+    { id: 3, name: 'メンズ' },
+    { id: 4, name: 'ベビー・キッズ' },
+    { id: 5, name: 'インテリア・住まい・小物' },
+    { id: 6, name: '本・音楽・ゲーム' },
+    { id: 7, name: 'おもちゃ・ホビー・ゲーム' },
+    { id: 8, name: '家電・スマホ・カメラ' },
+    { id: 9, name: 'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
+  ]
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,13 +1,12 @@
 class Condition < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
-    { id: 2, name: '新品・未使用'},
-    { id: 3, name: '未使用に近い'},
-    { id: 4, name: '目立った傷や汚れなし'},
-    { id: 5, name: 'やや傷や汚れあり'},
-    { id: 6, name: '傷や汚れあり'}
+    { id: 2, name: '新品・未使用' },
+    { id: 3, name: '未使用に近い' },
+    { id: 4, name: '目立った傷や汚れなし' },
+    { id: 5, name: 'やや傷や汚れあり' },
+    { id: 6, name: '傷や汚れあり' }
   ]
   include ActiveHash::Associations
   has_many :items
 end
-

--- a/app/models/delivery_day.rb
+++ b/app/models/delivery_day.rb
@@ -1,11 +1,10 @@
 class DeliveryDay < ActiveHash::Base
-
   self.data = [
     { id: 1, name: '--' },
-    { id: 2, name: '１〜２日で発送'},
-    { id: 3, name: '２〜３日で発送'},
-    { id: 4, name: '４〜７日で発送'}
+    { id: 2, name: '１〜２日で発送' },
+    { id: 3, name: '２〜３日で発送' },
+    { id: 4, name: '４〜７日で発送' }
   ]
   include ActiveHash::Associations
- has_many :items
+  has_many :items
 end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -1,11 +1,9 @@
 class DeliveryFee < ActiveHash::Base
-
   self.data = [
     { id: 1, name: '--' },
-    { id: 2, name: '着払い'},
-    { id: 3, name: '送料込み'}
+    { id: 2, name: '着払い' },
+    { id: 3, name: '送料込み' }
   ]
   include ActiveHash::Associations
- has_many :items
- 
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-  
+
   belongs_to :user
   has_one :buy
   has_one_attached :image
@@ -10,14 +10,14 @@ class Item < ApplicationRecord
   belongs_to :prefecture
   belongs_to :delivery_day
 
-
   with_options presence: true do
     validates :image
     validates :name
     validates :explanation
-    validates :price, format: { with: /\A[0-9]+\z/ ,message:'half-width number'},  inclusion: { in: 300..9_999_999 ,message:'Out of setting range'}
-    with_options numericality: { other_than: 1 ,message: 'Select'} do
-      validates :category_id 
+    validates :price, format: { with: /\A[0-9]+\z/, message: 'half-width number' },
+                      inclusion: { in: 300..9_999_999, message: 'Out of setting range' }
+    with_options numericality: { other_than: 1, message: 'Select' } do
+      validates :category_id
       validates :condition_id
       validates :delivery_fee_id
       validates :prefecture_id

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,23 +1,22 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    { id: 1, name: '--' },{id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-      {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-      {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-      {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-      {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-      {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-      {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-      {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-      {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-      {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-      {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-      {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-      {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-      {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-      {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-      {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    { id: 1, name: '--' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
+    { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
+    { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' },
+    { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, { id: 37, name: '徳島県' },
+    { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' },
+    { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
   include ActiveHash::Associations
   has_many :items
 end
-  

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,19 +5,18 @@ class User < ApplicationRecord
   has_many :buys
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-         validates :email,                 uniqueness: true
-         validates :password,format:{with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: "Include both letters and numbers" }
-         with_options presence: true do
-           validates :nickname
-           validates :birthday
-           with_options format: { with: /\A[ぁ-んァ-ヶ一-龥々]+\z/, message: "Full-width characters"} do
-            validates :family_name 
-            validates :first_name
-           end
-           with_options format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: "Full-width katakana characters" } do
-             validates :family_name_kana
-             validates :first_name_kana
-           end
-         end
-         
+  validates :email,                 uniqueness: true
+  validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'Include both letters and numbers' }
+  with_options presence: true do
+    validates :nickname
+    validates :birthday
+    with_options format: { with: /\A[ぁ-んァ-ヶ一-龥々]+\z/, message: 'Full-width characters' } do
+      validates :family_name
+      validates :first_name
+    end
+    with_options format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: 'Full-width katakana characters' } do
+      validates :family_name_kana
+      validates :first_name_kana
+    end
+  end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item,local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: @item %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id,:name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id,:name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_day_id, DeliveryDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる',item_path , class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
         </span>
     <% if user_signed_in?%>
       <%if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,6 +23,7 @@
         <span class="item-postage">
           <%= @item.delivery_fee.name %>
         </span>
+       </div>
     <% if user_signed_in?%>
       <%if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
@@ -31,7 +32,7 @@
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>
-      </div>
+
     <% end %>
 
     <div class="item-explain-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root to: "items#index"
   devise_for :users
-  resources :items, only: [:index, :new, :create,:show]
+  resources :items, only: [:index, :new, :create,:show,:edit,:update]
 
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
     name                   { Faker::Name.initials(number: 6) }
-    explanation            { Faker::Lorem.sentence}
-    price                  { 10000 }
+    explanation            { Faker::Lorem.sentence }
+    price                  { 10_000 }
     category_id            { 2 }
     condition_id           { 2 }
     delivery_fee_id        { 2 }
     prefecture_id          { 2 }
-    delivery_day_id        { 2 } 
+    delivery_day_id        { 2 }
     association :user
 
     after(:build) do |item|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :user do
     nickname               { Faker::Name.initials(number: 6) }
     email                  { Faker::Internet.free_email }
-    password               {  '1a' + Faker::Internet.password(min_length: 7) }
+    password               { '1a' + Faker::Internet.password(min_length: 7) }
     password_confirmation  { password }
-    family_name            { "あ" }
-    first_name             { "あ" }
-    family_name_kana       { "ア" }
-    first_name_kana        { "ア"}
-    birthday               { "1987-11-17" }
+    family_name            { 'あ' }
+    first_name             { 'あ' }
+    family_name_kana       { 'ア' }
+    first_name_kana        { 'ア' }
+    birthday               { '1987-11-17' }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,31 +34,31 @@ RSpec.describe Item, type: :model do
       it 'category_idが--では投稿できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category Select")
+        expect(@item.errors.full_messages).to include('Category Select')
       end
 
       it 'condition_idが--では投稿できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition Select")
+        expect(@item.errors.full_messages).to include('Condition Select')
       end
 
       it 'delivery_fee_idが--では投稿できない' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee Select")
+        expect(@item.errors.full_messages).to include('Delivery fee Select')
       end
 
       it 'prefecture_idが--では投稿できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture Select")
+        expect(@item.errors.full_messages).to include('Prefecture Select')
       end
 
       it 'delivery_day_idが--では投稿できない' do
         @item.delivery_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery day Select")
+        expect(@item.errors.full_messages).to include('Delivery day Select')
       end
 
       it '価格は空では登録できないこと' do
@@ -68,34 +68,33 @@ RSpec.describe Item, type: :model do
       end
 
       it '価格は全角文字では登録できないこと' do
-        @item.price = "５００００"
+        @item.price = '５００００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
 
       it '価格は半角英語だけでは登録できないこと' do
-        @item.price = "aaaaaaaaaa"
+        @item.price = 'aaaaaaaaaa'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
 
       it '価格は半角英数混合では登録できないこと' do
-        @item.price = "1a1a1a1a1a"
+        @item.price = '1a1a1a1a1a'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
-
 
       it '価格は299円以下では登録できないこと' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
 
       it '価格は10,000,000以上では登録できないこと' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,148 +1,145 @@
 require 'rails_helper'
 
+describe User, type: :model do
+  before do
+    @user = FactoryBot.build(:user)
+  end
 
-  describe User, type: :model do
-    before do
-      @user = FactoryBot.build(:user)
+  describe 'ユーザー新規登録' do
+    context 'ユーザー新規登録できるとき' do
+      it 'すべての入力がなされていれば登録できる' do
+        expect(@user).to be_valid
+      end
+      it 'passwordとpassword_confirmationが6文字以上であれば登録できる' do
+        @user.password = 'aaa000'
+        @user.password_confirmation = 'aaa000'
+        expect(@user).to be_valid
+      end
+      it 'family_nameとfirst_nameが漢字・平仮名・カタカナなら登録ができる' do
+        @user.family_name = '振り間'
+        @user.first_name = '亜府利'
+        expect(@user).to be_valid
+      end
+      it 'family_name_kanaとfirst_name_kanaが全角カタカナなら登録ができる' do
+        @user.family_name_kana = 'フリマ'
+        @user.first_name_kana = 'アプリ'
+        expect(@user).to be_valid
+      end
     end
 
-
-    describe 'ユーザー新規登録' do
-      context'ユーザー新規登録できるとき' do
-
-        it 'すべての入力がなされていれば登録できる' do
-          expect(@user).to be_valid
-        end
-        it 'passwordとpassword_confirmationが6文字以上であれば登録できる' do
-          @user.password = 'aaa000'
-          @user.password_confirmation = 'aaa000'
-          expect(@user).to be_valid
-        end
-        it 'family_nameとfirst_nameが漢字・平仮名・カタカナなら登録ができる' do
-          @user.family_name = '振り間'
-          @user.first_name = '亜府利'
-          expect(@user).to be_valid
-        end
-        it 'family_name_kanaとfirst_name_kanaが全角カタカナなら登録ができる' do
-          @user.family_name_kana = 'フリマ'
-          @user.first_name_kana = 'アプリ'
-          expect(@user).to be_valid
-        end
-      end
-
-      context'ユーザー新規登録できないとき' do
-        it "nicknameが空だと登録できない" do
-          @user.nickname = " " 
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Nickname can't be blank")
-        end
-        it "emailが空だと登録できない" do
-          @user.email = " " 
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Email can't be blank")
-        end
-        it "emailが一意でないと登録できない" do
-          @user.save
-          another_user = FactoryBot.build(:user)
-          another_user.email = @user.email
-          another_user.valid?
-          expect(another_user.errors.full_messages).to include("Email has already been taken")
-        end
-        it "emailに＠が含まれていないと登録できない" do
-          @user.email = "test.com"
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Email is invalid")
-        end
-        
-        it "passwordが６文字以上でないと登録できない" do
-        @user.password = "1111a"
+    context 'ユーザー新規登録できないとき' do
+      it 'nicknameが空だと登録できない' do
+        @user.nickname = ' '
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
-        end
+        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      end
+      it 'emailが空だと登録できない' do
+        @user.email = ' '
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Email can't be blank")
+      end
+      it 'emailが一意でないと登録できない' do
+        @user.save
+        another_user = FactoryBot.build(:user)
+        another_user.email = @user.email
+        another_user.valid?
+        expect(another_user.errors.full_messages).to include('Email has already been taken')
+      end
+      it 'emailに＠が含まれていないと登録できない' do
+        @user.email = 'test.com'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Email is invalid')
+      end
 
-        it "passwordが空だと登録できない" do
-          @user.password = " "
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Password can't be blank")
-        end
+      it 'passwordが６文字以上でないと登録できない' do
+        @user.password = '1111a'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+      end
 
-        it "passwordとpassword_confirmationが同じでないと登録できない" do
-          @user.password = "11111a"
-          @user.password_confirmation = "22222a"
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-        end
+      it 'passwordが空だと登録できない' do
+        @user.password = ' '
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password can't be blank")
+      end
 
-        it "Passwordは半角英語のみでは登録できないこと" do
-          @user.password = "aaaaaaa"
-          @user.password_confirmation = "aaaaaaa"
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
-        end
+      it 'passwordとpassword_confirmationが同じでないと登録できない' do
+        @user.password = '11111a'
+        @user.password_confirmation = '22222a'
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      end
 
-        it "Passwordは数字のみでは登録できないこと" do
-          @user.password = "1111111"
-          @user.password_confirmation = "1111111"
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
-        end
+      it 'Passwordは半角英語のみでは登録できないこと' do
+        @user.password = 'aaaaaaa'
+        @user.password_confirmation = 'aaaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+      end
 
-        it "Passwordは全角英数混合では登録できないこと" do
-          @user.password = "あんあんあん"
-          @user.password_confirmation = "あんあんあん"
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Password Include both letters and numbers")
-        end
+      it 'Passwordは数字のみでは登録できないこと' do
+        @user.password = '1111111'
+        @user.password_confirmation = '1111111'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+      end
 
-        it "family_nameが空では登録できないこと" do
-          @user.family_name = " "
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "Family name can't be blank" )
-        end
+      it 'Passwordは全角英数混合では登録できないこと' do
+        @user.password = 'あんあんあん'
+        @user.password_confirmation = 'あんあんあん'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+      end
 
-        it "first_nameが空では登録できないこと" do
-          @user.first_name = " "
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "First name can't be blank" )
-        end
+      it 'family_nameが空では登録できないこと' do
+        @user.family_name = ' '
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Family name can't be blank")
+      end
 
-        it "family_nameが漢字・平仮名・カタカナ以外では登録できないこと" do
-          @user.first_name = "aaaaaa"
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "First name Full-width characters" )
-        end
-        it "first_nameが漢字・平仮名・カタカナ以外では登録できないこと" do
-          @user.first_name = "aaaaaa"
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "First name Full-width characters" )
-        end
+      it 'first_nameが空では登録できないこと' do
+        @user.first_name = ' '
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name can't be blank")
+      end
 
-        it "family_name_kanaが空では登録できないこと" do
-          @user.family_name_kana = " "
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "Family name kana can't be blank" )
-        end
+      it 'family_nameが漢字・平仮名・カタカナ以外では登録できないこと' do
+        @user.first_name = 'aaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name Full-width characters')
+      end
+      it 'first_nameが漢字・平仮名・カタカナ以外では登録できないこと' do
+        @user.first_name = 'aaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name Full-width characters')
+      end
 
-        it "first_name_kanaが空では登録できないこと" do
-          @user.first_name_kana = " "
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "First name kana can't be blank" )
-        end
-        it "family_name_kanaが全角カタカナ以外では登録できないこと" do
-          @user.family_name_kana = "aaaaaa"
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "Family name kana Full-width katakana characters" )
-        end
-        it "first_name_kanaが全角カタカナ以外では登録できないこと" do
-          @user.first_name_kana = "aaaaaa"
-          @user.valid?
-          expect(@user.errors.full_messages).to include( "First name kana Full-width katakana characters" )
-        end
-        it "birthdayが空だと登録できない" do
-          @user.birthday = " "
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Birthday can't be blank")
-        end
+      it 'family_name_kanaが空では登録できないこと' do
+        @user.family_name_kana = ' '
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Family name kana can't be blank")
+      end
+
+      it 'first_name_kanaが空では登録できないこと' do
+        @user.first_name_kana = ' '
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+      end
+      it 'family_name_kanaが全角カタカナ以外では登録できないこと' do
+        @user.family_name_kana = 'aaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Family name kana Full-width katakana characters')
+      end
+      it 'first_name_kanaが全角カタカナ以外では登録できないこと' do
+        @user.first_name_kana = 'aaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name kana Full-width katakana characters')
+      end
+      it 'birthdayが空だと登録できない' do
+        @user.birthday = ' '
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Birthday can't be blank")
       end
     end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get items_index_url
     assert_response :success
   end
-
 end


### PR DESCRIPTION
what
 商品情報の編集機能の実装

why
出品した情報を変更する必要がある場合、出品情報の編集・更新ができるようにするため。


毎度ご対応いただきましてありがとうございます！早速ではございますが、機能実装いたしましたので御確認頂ますようお願いいたします！以下、動画になります

* ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/c61682cee4a9c5c4004836add02a2705

* 正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/559600ca00ac7cc0a89fb754e58384b0

* 入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/15a039731bccf69832a0dcc4c20f9301

* 何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/bd8e47602bf5fea6e35307174f3d74cb

* ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/abfc299f7a681e90c84ff6f70363c462

* ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/d10abd9677ad6409bab6ad855ea95443

* 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/a2a7c95a771664fd3a0dc258648c0b3d
